### PR TITLE
Add option to bind to all interfaces, not just localhost

### DIFF
--- a/bin/capture
+++ b/bin/capture
@@ -45,16 +45,16 @@ function wrapText(str, columns) {
     if (!str) {
         return str;
     }
-
     var lines = str.split('\n');
     return lines.map(function (l) { return wrapLine(l, columns); }).join('\n');
 }
 
 var executed = false;
 
-program.version('0.2.6') // automatically updated from package.json
+program.version('0.2.7') // automatically updated from package.json
     .usage('<applicationRoot> [options]')
     .option('-p, --port <portNumber>', 'Port number to start listening on [8000]', '8000')
+    .option('-B, --bindall', 'Bind to all interfaces (not just localhost)')
     .option('-r, --response', 'Save responses')
     .option('-R, --request', 'Save requests and responses')
     .option('-o, --output [location]', 'When request or response capture is enabled, save files to this folder [./output]', './output')
@@ -112,6 +112,7 @@ if (!executed) {
     }
 
     capture.listen(applicationRoot, program.port, {
+        bindall: program.bindall,
         response: program.response,
         request: program.request,
         output: require('path').resolve(process.cwd(), program.output),

--- a/src/capture.js
+++ b/src/capture.js
@@ -196,8 +196,9 @@ function listen (appRoot, port, options) {
         fsUtil.ensurePath(outputLocation);
     }
 
-    proxy.listen(port, 'localhost');
-    log('Proxy running on http://localhost:%s/ -> %s', port, appRoot);
+    var bindHost = options.bindall ? '0.0.0.0' : 'localhost';
+    proxy.listen(port, bindHost);
+    log('Proxy running on http://%s:%s/ -> %s', bindHost, port, appRoot);
 
     return proxy;
 }

--- a/tests/connect.js
+++ b/tests/connect.js
@@ -72,6 +72,16 @@ describe('connect', function () {
         }).to.throwException();
     });
 
+    it('should bind to localhost by default', function () {
+        listen('http://my.host.com', port, { });
+        expect(proxy.listen.args[0]).to.eql([port, 'localhost']);
+    });
+
+    it('should bind to all ports when requested', function () {
+        listen('http://my.host.com', port, { bindall: true });
+        expect(proxy.listen.args[0]).to.eql([port, '0.0.0.0']);
+    });
+
     describe('requests', function () {
         function triggerRequest (requestHeaders) {
             expect(http.createServer.args[0][0]).to.be.a(Function);


### PR DESCRIPTION
Hi @socsieng,

Thanks for creating this handy tool.  We definitely found your capturing proxy easy/straightforward to use, and we were able to leverage it to troubleshoot an issue with a service...with one small issue...

When the app binds (listens) on a port on `localhost` (hardcoded), it prevented us from proxying requests from an external host (in our case, an external load balancer).

So we submit this PR in hopes that the `-A, --bindall` flag can allow users to choose if they would like the proxy to bind to all interfaces (via `0.0.0.0`).  The original behavior of binding only to localhost (presumably for development/testing) is preserved.

Thanks again!